### PR TITLE
add test data for subreddit dashboard queries

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12294,12 +12294,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -12314,17 +12316,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -12441,7 +12446,8 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -12453,6 +12459,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -12467,6 +12474,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -12587,7 +12595,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -12720,6 +12729,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/backend/schema.gql
+++ b/backend/schema.gql
@@ -4,6 +4,14 @@
 
 type Query {
   currentUser: UserModel!
+  subreddit: RedditModel!
+}
+
+type RedditModel {
+  link: String!
+  description: String
+  icon: String
+  answerCount: Float
 }
 
 type UserModel {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,11 +3,13 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { Request } from 'express';
 import { AuthModule } from './modules/auth/auth.module';
 import { UserModule } from './modules/user/user.module';
+import { RedditModule } from './modules/reddit/reddit.module';
 
 @Module({
   imports: [
     AuthModule,
     UserModule,
+    RedditModule,
     GraphQLModule.forRoot({
       debug: false,
       playground: true,

--- a/backend/src/modules/reddit/reddit.model.ts
+++ b/backend/src/modules/reddit/reddit.model.ts
@@ -1,0 +1,16 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class RedditModel {
+  @Field()
+  link!: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field({ nullable: true })
+  icon?: string;
+
+  @Field({ nullable: true })
+  answerCount?: number;
+}

--- a/backend/src/modules/reddit/reddit.module.ts
+++ b/backend/src/modules/reddit/reddit.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RedditResolver } from './reddit.resolver';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  providers: [RedditResolver],
+  imports: [AuthModule],
+})
+export class RedditModule {}

--- a/backend/src/modules/reddit/reddit.resolver.ts
+++ b/backend/src/modules/reddit/reddit.resolver.ts
@@ -1,0 +1,18 @@
+import { Query, Resolver } from '@nestjs/graphql';
+import { RedditModel } from './reddit.model';
+import { GqlAuthGuard } from '../auth/auth.guard';
+import { UseGuards } from '@nestjs/common';
+
+@Resolver(() => RedditModel)
+export class RedditResolver {
+  @Query(() => RedditModel)
+  @UseGuards(GqlAuthGuard)
+  subreddit(): RedditModel {
+    return {
+      link: "https://www.reddit.com/r/reactjs/",
+      description: "A community for learning and developing web applications using React by Facebook.",
+      icon: "https://api.adorable.io/avatars/285/abott@adorable.png",
+      answerCount: 6,
+    };
+  }
+}


### PR DESCRIPTION
This is the query for getting the data for the dashboard:
```
query {
  subreddit {
    link, 
    description,
    icon,
    answerCount
  }
}
```

This is the returned data:
```
      link: "https://www.reddit.com/r/reactjs/",
      description: "A community for learning and developing web applications using React by Facebook.",
      icon: "https://api.adorable.io/avatars/285/abott@adorable.png",
      answerCount: 6,
```
As the name of the subreddit should be displayed as a link, I included a link, from which the name can be extracted.